### PR TITLE
added pyserial instead of serial in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-serial
+pyserial


### PR DESCRIPTION
Changed [serial](https://pypi.org/project/serial/) to [pyserial](https://pypi.org/project/pyserial/) in `requirements.txt`, because [serial](https://pypi.org/project/serial/) is a different package. Therefore the script is not running if dependencies are installed via `requirements.txt`.